### PR TITLE
Allow alignments with multiple tokens, comma-separated

### DIFF
--- a/src/amr.py
+++ b/src/amr.py
@@ -571,7 +571,9 @@ expressive
                  :calendar (c2 / country :wiki "Japan"
                        :name (n2 / name :op1 "Japan"))))''',
 ''' (d / date-entity :polite +
-           :time (a / amr-unknown))'''
+           :time (a / amr-unknown))''',
+'''( o / have-01 :ARG0 o :value 2)''',
+#'''( o / have-01 :ARG0 o :value -2)'''  # causes errors if uncommented
 ]
 
 sembad_tests = [    # not a syntax error, but malformed in terms of variables

--- a/src/amr.py
+++ b/src/amr.py
@@ -21,12 +21,14 @@ from pprint import pprint
 from collections import defaultdict, namedtuple, Counter, Container
 
 from parsimonious.grammar import Grammar
+from parsimonious.exceptions import ParseError
 from nltk.parse import DependencyGraph
 
 def clean_grammar_file(s):
     return re.sub('\n[ \t]+', ' ', re.sub(r'#.*','',s.replace('\t',' ').replace('`','_backtick')))
 
-with open('amr.peg') as inF:
+scriptdir = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(scriptdir, 'amr.peg')) as inF:
     grammar = Grammar(clean_grammar_file(inF.read()))
 
 
@@ -255,7 +257,10 @@ class AMR(DependencyGraph):
         self.nodes[TOP]['type'] = 'TOP'
         if anno:
             self._anno = anno
-            p = grammar.parse(anno)
+            try:
+                p = grammar.parse(anno)
+            except ParseError as e:
+                raise AMRSyntaxError('Bad parse: '+str(e))
             if p is None:
                 raise AMRSyntaxError('Well-formedness error in annotation:\n'+anno.strip())
             self._analyze(p)

--- a/src/amr.py
+++ b/src/amr.py
@@ -370,6 +370,12 @@ class AMR(DependencyGraph):
                 :ARG1 p)
             :mod (s / strange))
         '''
+        def alignment_str(align_key, tokens):
+            s = '~' + align_key
+            if tokens:  # alignment key is like "e.10" (single token offset) or "e.10,11" (multiple)
+                s += '[' + ','.join(tokens[int(woffset)] for woffset in align_key.split('.')[1].split(',')) + ']'
+            return s
+        
         s = ''
         stack = []
         instance_fulfilled = None
@@ -378,7 +384,7 @@ class AMR(DependencyGraph):
             tokens = self.tokens()
         if align and tokens:
             for k,align_key in align.items():
-                align[k] = align_key + '['+tokens[int(align_key.split('.')[1])]+']'
+                align[k] = alignment_str(align_key, tokens)
         concept_stack_depth = {None: 0} # size of the stack when the :instance-of triple was encountered for the variable
         for h, r, d in self.triples()+[(None,None,None)]:
             if r==':top':
@@ -393,11 +399,7 @@ class AMR(DependencyGraph):
                 s += ' ' + r
                 if alignments and (h,r,d) in self._alignments:
                     align_key = self._alignments[(h,r,d)]
-                    s += '~' + align_key
-                    if tokens:  # assumption: one token per alignment key
-                        woffset = int(align_key.split('.')[1])
-                        s += '['+tokens[woffset]+']'
-
+                    s += alignment_str(align_key, tokens)
                 s += ' ' + d(align=align)
             else:
                 while len(stack)>concept_stack_depth[h]:
@@ -413,10 +415,7 @@ class AMR(DependencyGraph):
                     s += '\n' + indent*len(stack) + r
                     if alignments and (h,r,d) in self._alignments:
                         align_key = self._alignments[(h,r,d)]
-                        s += '~' + align_key
-                        if tokens:  # assumption: one token per alignment key
-                            woffset = int(align_key.split('.')[1])
-                            s += '['+tokens[woffset]+']'
+                        s += alignment_str(align_key, tokens)
                     s += ' (' + d(align=align)
                     stack.append(d)
                     instance_fulfilled = False


### PR DESCRIPTION
This should fix the error triggered by `e.3,4` in the test case. The reentrant variable's alignment may still cause an error.